### PR TITLE
Support JSX / other ECMA features

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -41,11 +41,11 @@ const PARSE_OPTIONS = {
 };
 
 export default class Module {
-  constructor(id: ?string, source: string) {
+  constructor(id: ?string, source: string, ecmaFeatures: ?Object) {
     this.id = id;
     this.metadata = ({}: Object);
     this.source = source;
-    this.ast = parse(source, PARSE_OPTIONS);
+    this.ast = parse(source, Object.assign({}, PARSE_OPTIONS, { ecmaFeatures }));
     this.tokens = this.ast.tokens;
     delete this.ast.tokens;
     this.scopeManager = analyze(this.ast, { ecmaVersion: 6, sourceType: 'module' });

--- a/test/form/options/parses-jsx/_expected/ast.json
+++ b/test/form/options/parses-jsx/_expected/ast.json
@@ -1,0 +1,81 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "id": {
+            "type": "Identifier",
+            "name": "a"
+          },
+          "init": {
+            "type": "Literal",
+            "value": 1,
+            "raw": "1"
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "id": {
+            "type": "Identifier",
+            "name": "element"
+          },
+          "init": {
+            "type": "JSXElement",
+            "openingElement": {
+              "type": "JSXOpeningElement",
+              "name": {
+                "type": "JSXIdentifier",
+                "name": "a"
+              },
+              "selfClosing": false,
+              "attributes": [
+                {
+                  "type": "JSXAttribute",
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "name": "href"
+                  },
+                  "value": {
+                    "type": "JSXExpressionContainer",
+                    "expression": {
+                      "type": "Literal",
+                      "value": "http://google.com",
+                      "raw": "\"http://google.com\""
+                    }
+                  }
+                }
+              ]
+            },
+            "closingElement": {
+              "type": "JSXClosingElement",
+              "name": {
+                "type": "JSXIdentifier",
+                "name": "a"
+              }
+            },
+            "children": [
+              {
+                "type": "JSXExpressionContainer",
+                "expression": {
+                  "type": "Identifier",
+                  "name": "a"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    }
+  ],
+  "sourceType": "module"
+}

--- a/test/form/options/parses-jsx/_expected/main.js
+++ b/test/form/options/parses-jsx/_expected/main.js
@@ -1,0 +1,2 @@
+const a = 1;
+const element = <a href={"http://google.com"}>{a}</a>;

--- a/test/form/options/parses-jsx/_expected/metadata.json
+++ b/test/form/options/parses-jsx/_expected/metadata.json
@@ -1,0 +1,99 @@
+{
+  "objects.shorthand": {
+    "properties": []
+  },
+  "objects.concise": {
+    "properties": []
+  },
+  "modules.commonjs": {
+    "imports": [],
+    "exports": [],
+    "directives": []
+  },
+  "functions.arrow": {
+    "functions": []
+  },
+  "declarations.block-scope": {
+    "declarations": [
+      {
+        "type": "VariableDeclaration",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "id": {
+              "type": "Identifier",
+              "name": "a"
+            },
+            "init": {
+              "type": "Literal",
+              "value": 1,
+              "raw": "1"
+            }
+          }
+        ],
+        "kind": "var"
+      },
+      {
+        "type": "VariableDeclaration",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "id": {
+              "type": "Identifier",
+              "name": "element"
+            },
+            "init": {
+              "type": "JSXElement",
+              "openingElement": {
+                "type": "JSXOpeningElement",
+                "name": {
+                  "type": "JSXIdentifier",
+                  "name": "a"
+                },
+                "selfClosing": false,
+                "attributes": [
+                  {
+                    "type": "JSXAttribute",
+                    "name": {
+                      "type": "JSXIdentifier",
+                      "name": "href"
+                    },
+                    "value": {
+                      "type": "JSXExpressionContainer",
+                      "expression": {
+                        "type": "Literal",
+                        "value": "http://google.com",
+                        "raw": "\"http://google.com\""
+                      }
+                    }
+                  }
+                ]
+              },
+              "closingElement": {
+                "type": "JSXClosingElement",
+                "name": {
+                  "type": "JSXIdentifier",
+                  "name": "a"
+                }
+              },
+              "children": [
+                {
+                  "type": "JSXExpressionContainer",
+                  "expression": {
+                    "type": "Identifier",
+                    "name": "a"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "kind": "var"
+      }
+    ]
+  },
+  "objects.destructuring": [],
+  "strings.template": {
+    "concatenations": []
+  }
+}

--- a/test/form/options/parses-jsx/config.json
+++ b/test/form/options/parses-jsx/config.json
@@ -1,0 +1,7 @@
+{
+  "options": {
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  }
+}

--- a/test/form/options/parses-jsx/main.js
+++ b/test/form/options/parses-jsx/main.js
@@ -1,0 +1,2 @@
+var a = 1;
+var element = <a href={"http://google.com"}>{a}</a>;


### PR DESCRIPTION
I wanted to get some feedback to see if this is the best way to do this. If I get the green light, I can add tests around this.

The idea is that a user of this library can pass in `ecmaFeatures` options into `espree`.