### PR TITLE
fix: don't crash when the export object contains non-identifiers

### DIFF
--- a/src/plugins/modules.commonjs.js
+++ b/src/plugins/modules.commonjs.js
@@ -189,6 +189,20 @@ function isExportsObject(path: Path): boolean {
   }
 }
 
+function isSimpleObjectExpression(node: Node) {
+  if (!t.isObjectExpression(node)) {
+    return false;
+  }
+  for (let property of node.properties) {
+    if (!t.isObjectProperty(property) ||
+        !t.isIdentifier(property.key) ||
+        !t.isIdentifier(property.value)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function rewriteSingleExportAsDefaultExport(path: Path, module: Module): boolean {
   let {
     node,
@@ -197,7 +211,7 @@ function rewriteSingleExportAsDefaultExport(path: Path, module: Module): boolean
     }
   } = path;
 
-  if (t.isObjectExpression(right)) {
+  if (isSimpleObjectExpression(right)) {
     let bindings = [];
 
     for (let { key, value } of right.properties) {

--- a/test/form/modules.commonjs/rewrites-assigning-a-complex-object-as-export-default/_expected/main.js
+++ b/test/form/modules.commonjs/rewrites-assigning-a-complex-object-as-export-default/_expected/main.js
@@ -1,0 +1,8 @@
+export default {
+  foo() {
+    return 1;
+  },
+  bar() {
+    return 2;
+  },
+};

--- a/test/form/modules.commonjs/rewrites-assigning-a-complex-object-as-export-default/_expected/metadata.json
+++ b/test/form/modules.commonjs/rewrites-assigning-a-complex-object-as-export-default/_expected/metadata.json
@@ -1,0 +1,99 @@
+{
+  "modules.commonjs": {
+    "imports": [],
+    "exports": [
+      {
+        "type": "default-export",
+        "node": {
+          "type": "ExpressionStatement",
+          "expression": {
+            "type": "AssignmentExpression",
+            "operator": "=",
+            "left": {
+              "type": "MemberExpression",
+              "object": {
+                "type": "Identifier",
+                "name": "module",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "property": {
+                "type": "Identifier",
+                "name": "exports",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "computed": false
+            },
+            "right": {
+              "type": "ObjectExpression",
+              "properties": [
+                {
+                  "type": "ObjectMethod",
+                  "kind": "method",
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "name": "foo",
+                    "decorators": null,
+                    "typeAnnotation": null
+                  },
+                  "decorators": null,
+                  "body": {
+                    "type": "BlockStatement",
+                    "directives": [],
+                    "body": [
+                      {
+                        "type": "ReturnStatement",
+                        "argument": {
+                          "type": "NumericLiteral",
+                          "value": 1
+                        }
+                      }
+                    ]
+                  },
+                  "generator": false,
+                  "async": false,
+                  "params": [],
+                  "returnType": null,
+                  "typeParameters": null
+                },
+                {
+                  "type": "ObjectMethod",
+                  "kind": "method",
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "name": "bar",
+                    "decorators": null,
+                    "typeAnnotation": null
+                  },
+                  "decorators": null,
+                  "body": {
+                    "type": "BlockStatement",
+                    "directives": [],
+                    "body": [
+                      {
+                        "type": "ReturnStatement",
+                        "argument": {
+                          "type": "NumericLiteral",
+                          "value": 2
+                        }
+                      }
+                    ]
+                  },
+                  "generator": false,
+                  "async": false,
+                  "params": [],
+                  "returnType": null,
+                  "typeParameters": null
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/rewrites-assigning-a-complex-object-as-export-default/main.js
+++ b/test/form/modules.commonjs/rewrites-assigning-a-complex-object-as-export-default/main.js
@@ -1,0 +1,8 @@
+module.exports = {
+  foo() {
+    return 1;
+  },
+  bar() {
+    return 2;
+  },
+};


### PR DESCRIPTION
This is a quick fix to fix a bunch of crashes I've seen in decaffeinate.
Currently the code assumes that exported object keys and values are identifiers,
and crashes if they're not. With this change, the code instead falls back to the
normal `export default` case with the object.

@eventualbuddha , I wrote this before I saw you had assigned #92 to yourself, I hope I'm not stepping on your toes. I saw you have more interesting plans in #90, but fixing the crash as a stopgap would be nice.