### PR TITLE
fix: include more information on intermediate parse errors

### DIFF
--- a/src/esnext.js
+++ b/src/esnext.js
@@ -38,8 +38,14 @@ export function convert(source: string, options: (Options|Array<Plugin>)={}): Re
   plugins.forEach(plugin => {
     let { name, visitor } = plugin;
     let pluginOptions = options[name];
-    traverse(module.ast, visitor(module, pluginOptions));
-    module.commit();
+    try {
+      traverse(module.ast, visitor(module, pluginOptions));
+      module.commit();
+    } catch (e) {
+      e.message = `Error running plugin ${name}: ${e.message}`;
+      e.source = module.source;
+      throw e;
+    }
   });
 
   let result: RenderedModule = module.render();


### PR DESCRIPTION
This is the esnext side of a change to make the decaffeinate repl more useful
for figuring out intermediate esnext errors. When esnext throws a parse error,
the position information in the exception refers to the intermediate source
code, but decaffeinate interprets it as a position in the original code sent to
esnext, which leads to some confusing-looking errors, such as in this bug
report:

https://github.com/decaffeinate/decaffeinate/issues/500

To avoid this problem, we can include more context in the exception the source
code and the plugin that failed. Attaching this directly to the exception is a
little hacky, but works, and is nice because it keeps the stack trace.

Here's a demo of the decaffeinate repl with this change and a change in
decaffeinate to take advantage of this change:
[repl](http://www.alangpierce.com/decaffeinate-project.org/repl/#?evaluate=true&stage=full&code=b%20%3D%20a%20or%20()%20-%3E%20'hello%20world')