### PR TITLE
fix: don't transform manually-bound generator functions into arrow functions

### DIFF
--- a/src/plugins/functions.arrow.js
+++ b/src/plugins/functions.arrow.js
@@ -102,6 +102,10 @@ export function visitor(module: Module): Visitor {
         return;
       }
 
+      if (objectPath.node.generator) {
+        return;
+      }
+
       rewriteBlockArrowFunction(objectPath, module, functions);
 
       // `() => {}.bind(this)` -> `() => {}bind(this)`

--- a/test/form/functions.arrow/skips-bound-generator-functions/_expected/main.js
+++ b/test/form/functions.arrow/skips-bound-generator-functions/_expected/main.js
@@ -1,0 +1,1 @@
+a(function*() { yield 0; }.bind(this));

--- a/test/form/functions.arrow/skips-bound-generator-functions/_expected/metadata.json
+++ b/test/form/functions.arrow/skips-bound-generator-functions/_expected/metadata.json
@@ -1,0 +1,5 @@
+{
+  "functions.arrow": {
+    "functions": []
+  }
+}

--- a/test/form/functions.arrow/skips-bound-generator-functions/main.js
+++ b/test/form/functions.arrow/skips-bound-generator-functions/main.js
@@ -1,0 +1,1 @@
+a(function*() { yield 0; }.bind(this));


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/516

There's no arrow function syntax for generator functions, so we need to keep
them as-is.