### PR TITLE
fix: wrap arrow functions in parens when used in an || expression

### DIFF
--- a/src/utils/needsParens.js
+++ b/src/utils/needsParens.js
@@ -11,6 +11,8 @@ export function needsParens(path: Path): boolean {
       return parent.callee === node;
     } else if (t.isBinaryExpression(parent)) {
       return true;
+    } else if (t.isLogicalExpression(parent)) {
+      return true;
     }
   }
 

--- a/test/form/functions.arrow/needs-parens-in-or-expression/_expected/main.js
+++ b/test/form/functions.arrow/needs-parens-in-or-expression/_expected/main.js
@@ -1,0 +1,1 @@
+a || (() => 'hello world');

--- a/test/form/functions.arrow/needs-parens-in-or-expression/_expected/metadata.json
+++ b/test/form/functions.arrow/needs-parens-in-or-expression/_expected/metadata.json
@@ -1,0 +1,28 @@
+{
+  "functions.arrow": {
+    "functions": [
+      {
+        "type": "FunctionExpression",
+        "id": null,
+        "params": [],
+        "body": {
+          "type": "BlockStatement",
+          "directives": [],
+          "body": [
+            {
+              "type": "ReturnStatement",
+              "argument": {
+                "type": "StringLiteral",
+                "value": "hello world"
+              }
+            }
+          ]
+        },
+        "generator": false,
+        "async": false,
+        "returnType": null,
+        "typeParameters": null
+      }
+    ]
+  }
+}

--- a/test/form/functions.arrow/needs-parens-in-or-expression/main.js
+++ b/test/form/functions.arrow/needs-parens-in-or-expression/main.js
@@ -1,0 +1,1 @@
+a || function() { return 'hello world'; };


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/500

Looks like `||` isn't a BinaryExpression, it's a LogicalExpression, so we need
to check for that as well.