### PR TITLE
fix: expose allPlugins as an export

### DIFF
--- a/src/esnext.js
+++ b/src/esnext.js
@@ -20,6 +20,8 @@ type Options = {
   'declarations.block-scope'?: ?DeclarationsBlockScopeOptions,
 };
 
+export { allPlugins };
+
 export function convert(source: string, options: (Options|Array<Plugin>)={}): RenderedModule {
   if (Array.isArray(options)) {
     console.warn('convert(source, plugins) is deprecated, please call as convert(source, options)'); // eslint-disable-line no-console


### PR DESCRIPTION
Fixes #104

This makes it so callers can actually pass in the list of plugins as an option,
potentially with some entries filtered.