### PR TITLE
fix: update magic-string dependency and update usage to avoid warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "babel-traverse": "^6.18.0",
     "babel-types": "^6.18.0",
     "babylon": "^6.13.1",
-    "magic-string": "^0.15.2",
+    "magic-string": "^0.19.0",
     "mkdirp": "^0.5.1",
     "shebang-regex": "^2.0.0",
     "strip-indent": "^2.0.0"

--- a/src/plugins/functions.arrow.js
+++ b/src/plugins/functions.arrow.js
@@ -230,7 +230,7 @@ function rewriteBlocklessArrowFunction(path: Path, module: Module, functions: Ar
     //  }
     //
     if (blockStart.end === statement.start) {
-      editor.insertLeft(statement.start, ' ');
+      editor.appendLeft(statement.start, ' ');
     } else {
       editor.overwrite(blockStart.end, statement.start, ' ');
     }
@@ -247,7 +247,7 @@ function rewriteBlocklessArrowFunction(path: Path, module: Module, functions: Ar
     returnArgumentNeedsParens ? '(' : ''
   );
   if (statement.argument.end === statement.end) {
-    editor.insertLeft(
+    editor.appendLeft(
       statement.end,
       returnArgumentNeedsParens ? ')' : ''
     );
@@ -267,13 +267,13 @@ function rewriteBlocklessArrowFunction(path: Path, module: Module, functions: Ar
   node.expression = true;
 
   if (needsParens(path) && !hasParens(path, module)) {
-    editor.insertRight(node.start, '(');
-    editor.insertLeft(node.end, ')');
+    editor.appendRight(node.start, '(');
+    editor.appendLeft(node.end, ')');
   }
 
   if (bodyNeedsParens(node.body)) {
-    editor.insertRight(node.body.start, '(');
-    editor.insertLeft(node.body.end, ')');
+    editor.appendRight(node.body.start, '(');
+    editor.appendLeft(node.body.end, ')');
   }
 }
 
@@ -305,7 +305,7 @@ function rewriteBlockArrowFunction(path: Path, module: Module, functions: Array<
   // `function() {` -> `() =>`
   //  ^^^^^^^^   ^         ^^
   editor.remove(fn.start, paramsStart.start);
-  editor.insertLeft(blockStart.start, '=> ');
+  editor.appendLeft(blockStart.start, '=> ');
 
   node.type = 'ArrowFunctionExpression';
 }

--- a/src/plugins/modules.commonjs.js
+++ b/src/plugins/modules.commonjs.js
@@ -304,7 +304,7 @@ function rewriteNamedFunctionExpressionExport(path: Path, module: Module) {
     module.magicString.overwrite(node.start, right.start, 'export ');
 
     if (!id) {
-      module.magicString.insertLeft(right.start + 'function'.length, ` ${localName}`);
+      module.magicString.appendLeft(right.start + 'function'.length, ` ${localName}`);
       right.id = t.identifier(exportName);
     }
 
@@ -324,7 +324,7 @@ function rewriteNamedFunctionExpressionExport(path: Path, module: Module) {
 
     if (!id) {
       module.magicString.remove(node.start, right.start);
-      module.magicString.insertLeft(right.start + 'function'.length, ` ${localName}`);
+      module.magicString.appendLeft(right.start + 'function'.length, ` ${localName}`);
       right.type = 'FunctionDeclaration';
       right.id = localId;
     } else if (fnBinding === localName) {
@@ -344,7 +344,7 @@ function rewriteNamedFunctionExpressionExport(path: Path, module: Module) {
       );
     }
 
-    module.magicString.insertRight(node.end, `\nexport { ${localName} as ${exportName} };`);
+    module.magicString.appendRight(node.end, `\nexport { ${localName} as ${exportName} };`);
 
     path.replaceWithMultiple([
       declaration,
@@ -421,7 +421,7 @@ function rewriteNamedIdentifierExport(path: Path, module: Module): boolean {
       ];
     } else {
       module.magicString.overwrite(node.start, right.start, `let ${localBinding} = `);
-      module.magicString.insertRight(node.end, `\nexport { ${localBinding} as ${property.name} };`);
+      module.magicString.appendRight(node.end, `\nexport { ${localBinding} as ${property.name} };`);
       replacements = [
         t.variableDeclaration(
           'let',
@@ -523,10 +523,10 @@ function rewriteNamedValueExport(path: Path, module: Module): boolean {
 
     if (nextStatement) {
       // Insert before the next statement…
-      module.magicString.insertRight(nextStatement.start, `${exportStatement}\n`);
+      module.magicString.appendRight(nextStatement.start, `${exportStatement}\n`);
     } else {
       // …or after the last one of the program.
-      module.magicString.insertLeft(node.end, `\n${exportStatement}`);
+      module.magicString.appendLeft(node.end, `\n${exportStatement}`);
     }
 
     path.replaceWithMultiple([

--- a/src/plugins/objects.destructuring.js
+++ b/src/plugins/objects.destructuring.js
@@ -54,8 +54,8 @@ export function visitor(module: Module): Visitor {
 
       // `a = obj.a;` -> `(a = obj.a);`
       //                  ^         ^
-      module.magicString.insertLeft(assignments[0].start, '(');
-      module.magicString.insertRight(assignments[assignments.length - 1].end, ')');
+      module.magicString.appendLeft(assignments[0].start, '(');
+      module.magicString.appendRight(assignments[assignments.length - 1].end, ')');
 
       rewriteDestructurableElements(module, assignments);
 
@@ -89,8 +89,8 @@ export function visitor(module: Module): Visitor {
 
         if (assignments.length > 0 && index === 0) {
           // `a = obj.a;` -> `(a = obj.a);`
-          module.magicString.insertLeft(assignments[0].start, '(');
-          module.magicString.insertRight(assignments[assignments.length - 1].end, ')');
+          module.magicString.appendLeft(assignments[0].start, '(');
+          module.magicString.appendRight(assignments[assignments.length - 1].end, ')');
         }
 
         if (assignments.length > 0) {
@@ -171,7 +171,7 @@ function rewriteDestructurableElements(module: Module, elements: Array<Object>) 
 
   // `const a = obj.a, b = obj.b;` -> `const { a = obj.a, b = obj.b;`
   //                                         ^^
-  module.magicString.insertLeft(leftRightOfAssignment(firstElement).left.start, '{ ');
+  module.magicString.appendLeft(leftRightOfAssignment(firstElement).left.start, '{ ');
 
   for (let i = 0; i < elements.length - 1; i++) {
     let { left, right } = leftRightOfAssignment(elements[i]);
@@ -185,7 +185,7 @@ function rewriteDestructurableElements(module: Module, elements: Array<Object>) 
 
   // `const { a, b = obj.b;` -> `const { a, b } = obj.b;`
   //                                         ^^
-  module.magicString.insertRight(lastLeft.end, ' }');
+  module.magicString.appendRight(lastLeft.end, ' }');
 
   // `const { a, b } = obj.b;` -> `const { a, b } = obj;`
   //                      ^^

--- a/src/plugins/strings.template.js
+++ b/src/plugins/strings.template.js
@@ -118,13 +118,13 @@ function buildTemplateString(module: Module, node: Object, parts: Array<Object>)
   let cooked = '';
   let raw = '';
 
-  module.magicString.insertLeft(firstNode.start, '`');
+  module.magicString.appendLeft(firstNode.start, '`');
 
   parts.forEach(({ node, prefix, suffix }, i) => {
     if (prefix || suffix || !t.isStringLiteral(node)) {
       // This one has to be an interpolated expression.
-      module.magicString.insertRight(node.start, `\${${prefix}`);
-      module.magicString.insertLeft(node.end, `${suffix}}`);
+      module.magicString.appendRight(node.start, `\${${prefix}`);
+      module.magicString.appendLeft(node.end, `${suffix}}`);
       expressions.push(node);
       quasis.push(t.templateElement(
         { cooked, raw: escapeString('`', raw) },
@@ -158,7 +158,7 @@ function buildTemplateString(module: Module, node: Object, parts: Array<Object>)
   let lastPart = parts[parts.length - 1];
 
   if (lastPart.node.end === node.end) {
-    module.magicString.insertRight(
+    module.magicString.appendRight(
       node.end,
       '`'
     );

--- a/src/utils/escape.js
+++ b/src/utils/escape.js
@@ -21,7 +21,7 @@ export function escapeString(char: string, string: string, start: number=0, end:
   escape(
     char, start, end,
     index => string[index],
-    (index, string) => magicString.insertRight(index, string)
+    (index, string) => magicString.appendRight(index, string)
   );
   return magicString.toString();
 }


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/587

This was just a find-and-replace. Note that technically `insertRight` is
equivalent to `prependRight`, but `appendRight` is generally more well-behaved
(it inserts code in order), so it seems nice to switch to that.