### PR TITLE
fix: keep `var` declarations in loops in some unsafe-to-convert cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "bugs": "https://github.com/esnext/esnext/issues",
   "dependencies": {
-    "babel-traverse": "^6.18.0",
-    "babel-types": "^6.18.0",
-    "babylon": "^6.13.1",
+    "babel-traverse": "^6.21.0",
+    "babel-types": "^6.21.0",
+    "babylon": "^6.14.1",
     "magic-string": "^0.19.0",
     "mkdirp": "^0.5.1",
     "shebang-regex": "^2.0.0",

--- a/test/form/declarations.block-scope/var-loop-used-across-iterations/_expected/main.js
+++ b/test/form/declarations.block-scope/var-loop-used-across-iterations/_expected/main.js
@@ -1,0 +1,15 @@
+for (let a of [1, 2, 3]) {
+  var usedAcrossIterations;
+  let usedWithinIteration;
+  const initializedInLoop = true;
+  var conditionallyAssignedInLoop;
+  usedWithinIteration = true;
+  if (false) {
+    conditionallyAssignedInLoop = true;
+  }
+  console.log(usedAcrossIterations);
+  console.log(usedWithinIteration);
+  console.log(initializedInLoop);
+  console.log(conditionallyAssignedInLoop);
+  usedAcrossIterations = true;
+}

--- a/test/form/declarations.block-scope/var-loop-used-across-iterations/_expected/metadata.json
+++ b/test/form/declarations.block-scope/var-loop-used-across-iterations/_expected/metadata.json
@@ -1,0 +1,57 @@
+{
+  "declarations.block-scope": {
+    "declarations": [
+      {
+        "type": "VariableDeclaration",
+        "kind": "var",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "id": {
+              "type": "Identifier",
+              "name": "a",
+              "decorators": null,
+              "typeAnnotation": null
+            },
+            "init": null
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "kind": "var",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "id": {
+              "type": "Identifier",
+              "name": "usedWithinIteration",
+              "decorators": null,
+              "typeAnnotation": null
+            },
+            "init": null
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "kind": "var",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "id": {
+              "type": "Identifier",
+              "name": "initializedInLoop",
+              "decorators": null,
+              "typeAnnotation": null
+            },
+            "init": {
+              "type": "BooleanLiteral",
+              "value": true
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/form/declarations.block-scope/var-loop-used-across-iterations/_expected/warnings.json
+++ b/test/form/declarations.block-scope/var-loop-used-across-iterations/_expected/warnings.json
@@ -1,0 +1,112 @@
+[
+  {
+    "node": {
+      "type": "VariableDeclaration",
+      "start": 29,
+      "end": 54,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 2
+        },
+        "end": {
+          "line": 2,
+          "column": 27
+        }
+      },
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 33,
+          "end": 53,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 6
+            },
+            "end": {
+              "line": 2,
+              "column": 26
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 33,
+            "end": 53,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 26
+              },
+              "identifierName": "usedAcrossIterations"
+            },
+            "name": "usedAcrossIterations"
+          },
+          "init": null
+        }
+      ],
+      "kind": "var"
+    },
+    "type": "unsupported-declaration",
+    "message": "'var' declaration cannot be converted to block scope"
+  },
+  {
+    "node": {
+      "type": "VariableDeclaration",
+      "start": 116,
+      "end": 148,
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 2
+        },
+        "end": {
+          "line": 5,
+          "column": 34
+        }
+      },
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 120,
+          "end": 147,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 6
+            },
+            "end": {
+              "line": 5,
+              "column": 33
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 120,
+            "end": 147,
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 6
+              },
+              "end": {
+                "line": 5,
+                "column": 33
+              },
+              "identifierName": "conditionallyAssignedInLoop"
+            },
+            "name": "conditionallyAssignedInLoop"
+          },
+          "init": null
+        }
+      ],
+      "kind": "var"
+    },
+    "type": "unsupported-declaration",
+    "message": "'var' declaration cannot be converted to block scope"
+  }
+]

--- a/test/form/declarations.block-scope/var-loop-used-across-iterations/main.js
+++ b/test/form/declarations.block-scope/var-loop-used-across-iterations/main.js
@@ -1,0 +1,15 @@
+for (var a of [1, 2, 3]) {
+  var usedAcrossIterations;
+  var usedWithinIteration;
+  var initializedInLoop = true;
+  var conditionallyAssignedInLoop;
+  usedWithinIteration = true;
+  if (false) {
+    conditionallyAssignedInLoop = true;
+  }
+  console.log(usedAcrossIterations);
+  console.log(usedWithinIteration);
+  console.log(initializedInLoop);
+  console.log(conditionallyAssignedInLoop);
+  usedAcrossIterations = true;
+}

--- a/test/form/declarations.block-scope/var-loop-with-closure-reference/_expected/main.js
+++ b/test/form/declarations.block-scope/var-loop-with-closure-reference/_expected/main.js
@@ -1,0 +1,12 @@
+funcs = [];
+for (var a of [1, 2, 3]) {
+  var b = 4;
+  const c = 5;
+  funcs.append(function() {
+    console.log(a);
+  });
+  funcs.append(() => {
+    console.log(b);
+  });
+  console.log(c);
+}

--- a/test/form/declarations.block-scope/var-loop-with-closure-reference/_expected/metadata.json
+++ b/test/form/declarations.block-scope/var-loop-with-closure-reference/_expected/metadata.json
@@ -1,0 +1,25 @@
+{
+  "declarations.block-scope": {
+    "declarations": [
+      {
+        "type": "VariableDeclaration",
+        "kind": "var",
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "id": {
+              "type": "Identifier",
+              "name": "c",
+              "decorators": null,
+              "typeAnnotation": null
+            },
+            "init": {
+              "type": "NumericLiteral",
+              "value": 5
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/form/declarations.block-scope/var-loop-with-closure-reference/_expected/warnings.json
+++ b/test/form/declarations.block-scope/var-loop-with-closure-reference/_expected/warnings.json
@@ -1,0 +1,131 @@
+[
+  {
+    "node": {
+      "type": "VariableDeclaration",
+      "start": 17,
+      "end": 22,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 5
+        },
+        "end": {
+          "line": 2,
+          "column": 10
+        }
+      },
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 21,
+          "end": 22,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 9
+            },
+            "end": {
+              "line": 2,
+              "column": 10
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 21,
+            "end": 22,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 9
+              },
+              "end": {
+                "line": 2,
+                "column": 10
+              },
+              "identifierName": "a"
+            },
+            "name": "a"
+          },
+          "init": null
+        }
+      ],
+      "kind": "var"
+    },
+    "type": "unsupported-declaration",
+    "message": "'var' declaration cannot be converted to block scope"
+  },
+  {
+    "node": {
+      "type": "VariableDeclaration",
+      "start": 41,
+      "end": 51,
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 2
+        },
+        "end": {
+          "line": 3,
+          "column": 12
+        }
+      },
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 45,
+          "end": 50,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 6
+            },
+            "end": {
+              "line": 3,
+              "column": 11
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 45,
+            "end": 46,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 6
+              },
+              "end": {
+                "line": 3,
+                "column": 7
+              },
+              "identifierName": "b"
+            },
+            "name": "b"
+          },
+          "init": {
+            "type": "NumericLiteral",
+            "start": 49,
+            "end": 50,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 10
+              },
+              "end": {
+                "line": 3,
+                "column": 11
+              }
+            },
+            "extra": {
+              "rawValue": 4,
+              "raw": "4"
+            },
+            "value": 4
+          }
+        }
+      ],
+      "kind": "var"
+    },
+    "type": "unsupported-declaration",
+    "message": "'var' declaration cannot be converted to block scope"
+  }
+]

--- a/test/form/declarations.block-scope/var-loop-with-closure-reference/main.js
+++ b/test/form/declarations.block-scope/var-loop-with-closure-reference/main.js
@@ -1,0 +1,12 @@
+funcs = [];
+for (var a of [1, 2, 3]) {
+  var b = 4;
+  var c = 5;
+  funcs.append(function() {
+    console.log(a);
+  });
+  funcs.append(() => {
+    console.log(b);
+  });
+  console.log(c);
+}


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/624

Loops make variables tricky because `let` and `const` declarations get a new
variable instance for each loop iteration. This introduces two important
semantic differences:
* Closures referencing `var` variables reference the same variable across all
  iterations, whereas for `let`/`const` variables they reference the variable
  from the current iteration.
* `var` declarations without an initializer will have the value from the
  previous iteration. `let` declarations without an initializer will start as
  `undefined`.

To address these cases, I made the `bindingCouldBeBlockScope` function more
conservative. When a variable declaration is within a loop (that exists in the
same function scope as the declaration), we keep `var` if any reference exists
in a different function scope (i.e. within a closure). In the remaining cases,
we only convert to `let` or `const` if the variable is a loop assignee, is
initialized when it's declared, or when it has a top-level assignment before any
usage. This misses some cases that could be detected by more advanced static
analysis, but this approach probalby gets all of the common cases.

While I was at it, I changed some babel usages to use more concise methods,
which I discovered by reading through the [Babel Handbook](https://github.com/thejameskyle/babel-handbook/).

Funny enough, after I fixed this, the problem still occurred in my codebase
because the eslint auto-fixer for the [no-var](http://eslint.org/docs/rules/no-var) rule has the same bug.
I'll follow up with the eslint folks on a fix for that.