### PR TITLE
fix: properly transform functions starting with "use strict"

### DIFF
--- a/src/plugins/functions.arrow.js
+++ b/src/plugins/functions.arrow.js
@@ -43,6 +43,12 @@ export function visitor(module: Module): Visitor {
         return;
       }
 
+      // A directive like "use strict" is syntactically its own line, so if any
+      // exist, we can't assume this is a single-line function.
+      if (node.body.directives.length > 0) {
+        return;
+      }
+
       let [ statement ] = node.body.body;
 
       if (!t.isReturnStatement(statement) || !statement.argument) {

--- a/test/form/functions.arrow/string-on-first-line/_expected/main.js
+++ b/test/form/functions.arrow/string-on-first-line/_expected/main.js
@@ -1,0 +1,4 @@
+let x = function() {
+  'use strict';
+  return 1;
+};

--- a/test/form/functions.arrow/string-on-first-line/_expected/metadata.json
+++ b/test/form/functions.arrow/string-on-first-line/_expected/metadata.json
@@ -1,0 +1,5 @@
+{
+  "functions.arrow": {
+    "functions": []
+  }
+}

--- a/test/form/functions.arrow/string-on-first-line/main.js
+++ b/test/form/functions.arrow/string-on-first-line/main.js
@@ -1,0 +1,4 @@
+let x = function() {
+  'use strict';
+  return 1;
+};


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/794

Directives like "use strict" show up in a different place in the AST, so we need
to be a little more careful when determining if a function has only one line (so
that it could be changed to an expression-style arrow function).