### PR TITLE
fix: don't convert `new` expressions to arrow functions

### DIFF
--- a/src/plugins/functions.arrow.js
+++ b/src/plugins/functions.arrow.js
@@ -49,6 +49,11 @@ export function visitor(module: Module): Visitor {
         return;
       }
 
+      // `new` can't be called on arrow functions.
+      if (t.isNewExpression(parent)) {
+        return;
+      }
+
       let [ statement ] = node.body.body;
 
       if (!t.isReturnStatement(statement) || !statement.argument) {
@@ -82,7 +87,7 @@ export function visitor(module: Module): Visitor {
      *   }).bind(this);
      */
     CallExpression(path) {
-      let { node, node: { callee } } = path;
+      let { node, node: { callee }, parent } = path;
 
       if (!t.isMemberExpression(callee)) {
         return;
@@ -109,6 +114,12 @@ export function visitor(module: Module): Visitor {
       }
 
       if (objectPath.node.generator) {
+        return;
+      }
+
+      // `new` can't be called on arrow functions.
+      if (t.isNewExpression(parent)) {
+        path.skip();
         return;
       }
 

--- a/test/form/functions.arrow/skips-bound-functions-within-new/_expected/main.js
+++ b/test/form/functions.arrow/skips-bound-functions-within-new/_expected/main.js
@@ -1,0 +1,1 @@
+new (function() { return {a: 'b'}; }.bind(this));

--- a/test/form/functions.arrow/skips-bound-functions-within-new/_expected/metadata.json
+++ b/test/form/functions.arrow/skips-bound-functions-within-new/_expected/metadata.json
@@ -1,0 +1,5 @@
+{
+  "functions.arrow": {
+    "functions": []
+  }
+}

--- a/test/form/functions.arrow/skips-bound-functions-within-new/main.js
+++ b/test/form/functions.arrow/skips-bound-functions-within-new/main.js
@@ -1,0 +1,1 @@
+new (function() { return {a: 'b'}; }.bind(this));

--- a/test/form/functions.arrow/skips-functions-within-new/_expected/main.js
+++ b/test/form/functions.arrow/skips-functions-within-new/_expected/main.js
@@ -1,0 +1,1 @@
+new function() { return {a: 'b'}; };

--- a/test/form/functions.arrow/skips-functions-within-new/_expected/metadata.json
+++ b/test/form/functions.arrow/skips-functions-within-new/_expected/metadata.json
@@ -1,0 +1,5 @@
+{
+  "functions.arrow": {
+    "functions": []
+  }
+}

--- a/test/form/functions.arrow/skips-functions-within-new/main.js
+++ b/test/form/functions.arrow/skips-functions-within-new/main.js
@@ -1,0 +1,1 @@
+new function() { return {a: 'b'}; };


### PR DESCRIPTION
Progress toward https://github.com/decaffeinate/decaffeinate/issues/846

It's not allowed to call `new` on an arrow function, so if we can easily
determine that the function is in a `new` expression, skip it. Generally, this
property makes it impossible to determine for sure if it's safe to convert any
function to an arrow function, but this case seems obscure enough that it
shouldn't stop us from converting to arrow functions in normal-looking cases.