### PR TITLE
fix: traverse into arrow functions when searching for `this` usages

### DIFF
--- a/src/plugins/functions.arrow.js
+++ b/src/plugins/functions.arrow.js
@@ -150,7 +150,7 @@ function referencesThisOrArguments(path: Path): boolean {
   let result = false;
 
   path.scope.traverse(path.node, {
-    Function(fnPath) {
+    'FunctionDeclaration|FunctionExpression'(fnPath) {
       // Skip nested functions.
       fnPath.skip();
     },

--- a/test/form/functions.arrow/nested-arrow-within-non-arrow/_expected/main.js
+++ b/test/form/functions.arrow/nested-arrow-within-non-arrow/_expected/main.js
@@ -1,0 +1,8 @@
+{
+  foo: getFunc(function() {
+    return setImmediate(() => {
+        return this.foo2();
+      }
+    );
+  })
+};

--- a/test/form/functions.arrow/nested-arrow-within-non-arrow/_expected/metadata.json
+++ b/test/form/functions.arrow/nested-arrow-within-non-arrow/_expected/metadata.json
@@ -1,0 +1,5 @@
+{
+  "functions.arrow": {
+    "functions": []
+  }
+}

--- a/test/form/functions.arrow/nested-arrow-within-non-arrow/main.js
+++ b/test/form/functions.arrow/nested-arrow-within-non-arrow/main.js
@@ -1,0 +1,8 @@
+{
+  foo: getFunc(function() {
+    return setImmediate(() => {
+        return this.foo2();
+      }
+    );
+  })
+};


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/788

Previously, we stopped searching for `this` in any function, but in some cases,
the only `this` usage is within an arrow function, so we instead should only
stop on the two specific non-arrow-function node types.