### PR TITLE
fix: handle a default export on an expression wrapped in parens

### DIFF
--- a/src/plugins/modules.commonjs.js
+++ b/src/plugins/modules.commonjs.js
@@ -259,7 +259,14 @@ function rewriteSingleExportAsDefaultExport(path: Path, module: Module): boolean
       path.replaceWith(t.exportAllDeclaration(pathNode));
     } else {
       metadata(module).exports.push({ type: 'default-export', node: cleanNode(node) });
-      module.magicString.overwrite(node.start, right.start, 'export default ');
+
+      let equalsToken = findToken('=', module.tokensForNode(node));
+      let equalsEnd = equalsToken.token.end;
+      if (module.magicString.slice(equalsEnd, equalsEnd + 1) === ' ') {
+        equalsEnd++;
+      }
+      module.magicString.overwrite(node.start, equalsEnd, 'export default ');
+
       path.replaceWith(t.exportDefaultDeclaration(right));
     }
   }

--- a/test/form/modules.commonjs/export-default-class/_expected/main.js
+++ b/test/form/modules.commonjs/export-default-class/_expected/main.js
@@ -1,0 +1,2 @@
+let A;
+export default (A = class A {});

--- a/test/form/modules.commonjs/export-default-class/_expected/metadata.json
+++ b/test/form/modules.commonjs/export-default-class/_expected/metadata.json
@@ -1,0 +1,63 @@
+{
+  "modules.commonjs": {
+    "imports": [],
+    "exports": [
+      {
+        "type": "default-export",
+        "node": {
+          "type": "ExpressionStatement",
+          "expression": {
+            "type": "AssignmentExpression",
+            "operator": "=",
+            "left": {
+              "type": "MemberExpression",
+              "object": {
+                "type": "Identifier",
+                "name": "module",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "property": {
+                "type": "Identifier",
+                "name": "exports",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "computed": false
+            },
+            "right": {
+              "type": "AssignmentExpression",
+              "operator": "=",
+              "left": {
+                "type": "Identifier",
+                "name": "A",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "right": {
+                "type": "ClassExpression",
+                "id": {
+                  "type": "Identifier",
+                  "name": "A",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "body": {
+                  "type": "ClassBody",
+                  "body": []
+                },
+                "superClass": null,
+                "decorators": null,
+                "mixins": null,
+                "typeParameters": null,
+                "superTypeParameters": null,
+                "implements": null
+              }
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/export-default-class/main.js
+++ b/test/form/modules.commonjs/export-default-class/main.js
@@ -1,0 +1,2 @@
+var A;
+module.exports = (A = class A {});


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/969

Previously the overwrite logic would incorrectly destroy the open-paren.