### PR TITLE
fix: don't convert requires to imports after side effects

### DIFF
--- a/src/esnext.js
+++ b/src/esnext.js
@@ -13,11 +13,13 @@ type Plugin = {
 };
 
 import type { Options as DeclarationsBlockScopeOptions } from './plugins/declarations.block-scope';
+import type { Options as ModulesCommonJSOptions } from './plugins/modules.commonjs';
 
 type Options = {
   plugins?: Array<Plugin>,
   validate?: boolean,
   'declarations.block-scope'?: ?DeclarationsBlockScopeOptions,
+  'modules.commonjs'?: ?ModulesCommonJSOptions,
 };
 
 export { allPlugins };

--- a/src/utils/getFirstUnsafeLocation.js
+++ b/src/utils/getFirstUnsafeLocation.js
@@ -1,0 +1,70 @@
+import * as t from 'babel-types';
+import type { Path } from '../types';
+
+function hasMemberAccess(assignmentPath: Path): boolean {
+  if (t.isMemberExpression(assignmentPath.node)) {
+    return true;
+  }
+  let found = false;
+  assignmentPath.traverse({
+    MemberExpression(path: Path) {
+      found = true;
+      path.skip();
+    }
+  });
+  return found;
+}
+
+function hasIdentifier(calleePath: Path, names: Array<string>): boolean {
+  if (t.isIdentifier(calleePath.node) && names.indexOf(calleePath.node.name) !== -1) {
+    return true;
+  }
+  let found = false;
+  calleePath.traverse({
+    Identifier(path: Path) {
+      if (names.indexOf(path.node.name) !== -1) {
+        found = true;
+        path.skip();
+      }
+    }
+  });
+  return found;
+}
+
+/**
+ * Return the position of the first line of code that might affect the global
+ * object. Any require calls after this point cannot safely be turned into
+ * import statements, since import statements are hoisted.
+ */
+export default function getFirstUnsafeLocation(programPath: Path, allowedFunctionIdentifiers: Array<string>): number {
+  let resultLoc = programPath.node.end;
+  programPath.traverse({
+    AssignmentExpression(path: Path) {
+      if (hasMemberAccess(path.get('left'))) {
+        resultLoc = Math.min(resultLoc, path.node.start);
+        path.skip();
+      }
+    },
+    UpdateExpression(path: Path) {
+      if (hasMemberAccess(path.get('argument'))) {
+        resultLoc = Math.min(resultLoc, path.node.start);
+        path.skip();
+      }
+    },
+    CallExpression(path: Path) {
+      if (!hasIdentifier(path.get('callee'), allowedFunctionIdentifiers)) {
+        resultLoc = Math.min(resultLoc, path.node.start);
+        path.skip();
+      }
+    },
+    ReturnStatement(path: Path) {
+      resultLoc = Math.min(resultLoc, path.node.start);
+      path.skip();
+    },
+    ThrowStatement(path: Path) {
+      resultLoc = Math.min(resultLoc, path.node.start);
+      path.skip();
+    }
+  });
+  return resultLoc;
+}

--- a/test/form/modules.commonjs/converts-require-after-safe-call/_expected/main.js
+++ b/test/form/modules.commonjs/converts-require-after-safe-call/_expected/main.js
@@ -1,0 +1,3 @@
+import a from 'a';
+let b = React.createFactory(require('b'));
+import c from 'c';

--- a/test/form/modules.commonjs/converts-require-after-safe-call/_expected/metadata.json
+++ b/test/form/modules.commonjs/converts-require-after-safe-call/_expected/metadata.json
@@ -1,0 +1,88 @@
+{
+  "modules.commonjs": {
+    "imports": [
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "a",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "a"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "a",
+            "exportName": "default"
+          }
+        ],
+        "path": "a"
+      },
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "c",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "c"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "c",
+            "exportName": "default"
+          }
+        ],
+        "path": "c"
+      }
+    ],
+    "exports": [],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/converts-require-after-safe-call/_expected/warnings.json
+++ b/test/form/modules.commonjs/converts-require-after-safe-call/_expected/warnings.json
@@ -1,0 +1,60 @@
+[
+  {
+    "node": {
+      "type": "CallExpression",
+      "start": 50,
+      "end": 62,
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 28
+        },
+        "end": {
+          "line": 2,
+          "column": 40
+        }
+      },
+      "callee": {
+        "type": "Identifier",
+        "start": 50,
+        "end": 57,
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 28
+          },
+          "end": {
+            "line": 2,
+            "column": 35
+          },
+          "identifierName": "require"
+        },
+        "name": "require"
+      },
+      "arguments": [
+        {
+          "type": "StringLiteral",
+          "start": 58,
+          "end": 61,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 36
+            },
+            "end": {
+              "line": 2,
+              "column": 39
+            }
+          },
+          "extra": {
+            "rawValue": "b",
+            "raw": "'b'"
+          },
+          "value": "b"
+        }
+      ]
+    },
+    "type": "unsupported-import",
+    "message": "Unsupported 'require' call cannot be transformed into an import"
+  }
+]

--- a/test/form/modules.commonjs/converts-require-after-safe-call/config.json
+++ b/test/form/modules.commonjs/converts-require-after-safe-call/config.json
@@ -1,0 +1,7 @@
+{
+  "options": {
+    "modules.commonjs": {
+      "safeFunctionIdentifiers": ["createFactory"]
+    }
+  }
+}

--- a/test/form/modules.commonjs/converts-require-after-safe-call/main.js
+++ b/test/form/modules.commonjs/converts-require-after-safe-call/main.js
@@ -1,0 +1,3 @@
+let a = require('a');
+let b = React.createFactory(require('b'));
+let c = require('c');

--- a/test/form/modules.commonjs/skips-require-after-function-call/_expected/main.js
+++ b/test/form/modules.commonjs/skips-require-after-function-call/_expected/main.js
@@ -1,0 +1,5 @@
+import a from 'a';
+foo();
+import b from 'b';
+bar();
+let c = require('c');

--- a/test/form/modules.commonjs/skips-require-after-function-call/_expected/metadata.json
+++ b/test/form/modules.commonjs/skips-require-after-function-call/_expected/metadata.json
@@ -1,0 +1,88 @@
+{
+  "modules.commonjs": {
+    "imports": [
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "a",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "a"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "a",
+            "exportName": "default"
+          }
+        ],
+        "path": "a"
+      },
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "b",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "b"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "b",
+            "exportName": "default"
+          }
+        ],
+        "path": "b"
+      }
+    ],
+    "exports": [],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/skips-require-after-function-call/_expected/warnings.json
+++ b/test/form/modules.commonjs/skips-require-after-function-call/_expected/warnings.json
@@ -1,0 +1,60 @@
+[
+  {
+    "node": {
+      "type": "CallExpression",
+      "start": 66,
+      "end": 78,
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 8
+        },
+        "end": {
+          "line": 5,
+          "column": 20
+        }
+      },
+      "callee": {
+        "type": "Identifier",
+        "start": 66,
+        "end": 73,
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 8
+          },
+          "end": {
+            "line": 5,
+            "column": 15
+          },
+          "identifierName": "require"
+        },
+        "name": "require"
+      },
+      "arguments": [
+        {
+          "type": "StringLiteral",
+          "start": 74,
+          "end": 77,
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 16
+            },
+            "end": {
+              "line": 5,
+              "column": 19
+            }
+          },
+          "extra": {
+            "rawValue": "c",
+            "raw": "'c'"
+          },
+          "value": "c"
+        }
+      ]
+    },
+    "type": "unsupported-import",
+    "message": "Unsupported 'require' call cannot be transformed into an import"
+  }
+]

--- a/test/form/modules.commonjs/skips-require-after-function-call/config.json
+++ b/test/form/modules.commonjs/skips-require-after-function-call/config.json
@@ -1,0 +1,7 @@
+{
+  "options": {
+    "modules.commonjs": {
+      "safeFunctionIdentifiers": ["foo"]
+    }
+  }
+}

--- a/test/form/modules.commonjs/skips-require-after-function-call/main.js
+++ b/test/form/modules.commonjs/skips-require-after-function-call/main.js
@@ -1,0 +1,5 @@
+let a = require('a');
+foo();
+let b = require('b');
+bar();
+let c = require('c');

--- a/test/form/modules.commonjs/skips-require-after-increment/_expected/main.js
+++ b/test/form/modules.commonjs/skips-require-after-increment/_expected/main.js
@@ -1,0 +1,7 @@
+import a from 'a';
+import b from 'b';
+c = 1;
+d++;
+import e from 'e';
+window.f++;
+let g = require('g');

--- a/test/form/modules.commonjs/skips-require-after-increment/_expected/metadata.json
+++ b/test/form/modules.commonjs/skips-require-after-increment/_expected/metadata.json
@@ -1,0 +1,128 @@
+{
+  "modules.commonjs": {
+    "imports": [
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "a",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "a"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "a",
+            "exportName": "default"
+          }
+        ],
+        "path": "a"
+      },
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "b",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "b"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "b",
+            "exportName": "default"
+          }
+        ],
+        "path": "b"
+      },
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "e",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "e"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "e",
+            "exportName": "default"
+          }
+        ],
+        "path": "e"
+      }
+    ],
+    "exports": [],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/skips-require-after-increment/_expected/warnings.json
+++ b/test/form/modules.commonjs/skips-require-after-increment/_expected/warnings.json
@@ -1,0 +1,60 @@
+[
+  {
+    "node": {
+      "type": "CallExpression",
+      "start": 98,
+      "end": 110,
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 8
+        },
+        "end": {
+          "line": 7,
+          "column": 20
+        }
+      },
+      "callee": {
+        "type": "Identifier",
+        "start": 98,
+        "end": 105,
+        "loc": {
+          "start": {
+            "line": 7,
+            "column": 8
+          },
+          "end": {
+            "line": 7,
+            "column": 15
+          },
+          "identifierName": "require"
+        },
+        "name": "require"
+      },
+      "arguments": [
+        {
+          "type": "StringLiteral",
+          "start": 106,
+          "end": 109,
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 16
+            },
+            "end": {
+              "line": 7,
+              "column": 19
+            }
+          },
+          "extra": {
+            "rawValue": "g",
+            "raw": "'g'"
+          },
+          "value": "g"
+        }
+      ]
+    },
+    "type": "unsupported-import",
+    "message": "Unsupported 'require' call cannot be transformed into an import"
+  }
+]

--- a/test/form/modules.commonjs/skips-require-after-increment/main.js
+++ b/test/form/modules.commonjs/skips-require-after-increment/main.js
@@ -1,0 +1,7 @@
+let a = require('a');
+let b = require('b');
+c = 1;
+d++;
+let e = require('e');
+window.f++;
+let g = require('g');

--- a/test/form/modules.commonjs/skips-require-after-return/_expected/main.js
+++ b/test/form/modules.commonjs/skips-require-after-return/_expected/main.js
@@ -1,0 +1,4 @@
+import a from 'a';
+import b from 'b';
+return c;
+let d = require('d');

--- a/test/form/modules.commonjs/skips-require-after-return/_expected/metadata.json
+++ b/test/form/modules.commonjs/skips-require-after-return/_expected/metadata.json
@@ -1,0 +1,88 @@
+{
+  "modules.commonjs": {
+    "imports": [
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "a",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "a"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "a",
+            "exportName": "default"
+          }
+        ],
+        "path": "a"
+      },
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "b",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "b"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "b",
+            "exportName": "default"
+          }
+        ],
+        "path": "b"
+      }
+    ],
+    "exports": [],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/skips-require-after-return/_expected/warnings.json
+++ b/test/form/modules.commonjs/skips-require-after-return/_expected/warnings.json
@@ -1,0 +1,60 @@
+[
+  {
+    "node": {
+      "type": "CallExpression",
+      "start": 62,
+      "end": 74,
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 20
+        }
+      },
+      "callee": {
+        "type": "Identifier",
+        "start": 62,
+        "end": 69,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 8
+          },
+          "end": {
+            "line": 4,
+            "column": 15
+          },
+          "identifierName": "require"
+        },
+        "name": "require"
+      },
+      "arguments": [
+        {
+          "type": "StringLiteral",
+          "start": 70,
+          "end": 73,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 16
+            },
+            "end": {
+              "line": 4,
+              "column": 19
+            }
+          },
+          "extra": {
+            "rawValue": "d",
+            "raw": "'d'"
+          },
+          "value": "d"
+        }
+      ]
+    },
+    "type": "unsupported-import",
+    "message": "Unsupported 'require' call cannot be transformed into an import"
+  }
+]

--- a/test/form/modules.commonjs/skips-require-after-return/main.js
+++ b/test/form/modules.commonjs/skips-require-after-return/main.js
@@ -1,0 +1,4 @@
+let a = require('a');
+let b = require('b');
+return c;
+let d = require('d');

--- a/test/form/modules.commonjs/skips-require-after-side-effect/_expected/main.js
+++ b/test/form/modules.commonjs/skips-require-after-side-effect/_expected/main.js
@@ -1,0 +1,4 @@
+import a from 'a';
+import b from 'b';
+window.d = d;
+let e = require('e');

--- a/test/form/modules.commonjs/skips-require-after-side-effect/_expected/metadata.json
+++ b/test/form/modules.commonjs/skips-require-after-side-effect/_expected/metadata.json
@@ -1,0 +1,88 @@
+{
+  "modules.commonjs": {
+    "imports": [
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "a",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "a"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "a",
+            "exportName": "default"
+          }
+        ],
+        "path": "a"
+      },
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "b",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "b"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "b",
+            "exportName": "default"
+          }
+        ],
+        "path": "b"
+      }
+    ],
+    "exports": [],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/skips-require-after-side-effect/_expected/warnings.json
+++ b/test/form/modules.commonjs/skips-require-after-side-effect/_expected/warnings.json
@@ -1,0 +1,60 @@
+[
+  {
+    "node": {
+      "type": "CallExpression",
+      "start": 66,
+      "end": 78,
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 20
+        }
+      },
+      "callee": {
+        "type": "Identifier",
+        "start": 66,
+        "end": 73,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 8
+          },
+          "end": {
+            "line": 4,
+            "column": 15
+          },
+          "identifierName": "require"
+        },
+        "name": "require"
+      },
+      "arguments": [
+        {
+          "type": "StringLiteral",
+          "start": 74,
+          "end": 77,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 16
+            },
+            "end": {
+              "line": 4,
+              "column": 19
+            }
+          },
+          "extra": {
+            "rawValue": "e",
+            "raw": "'e'"
+          },
+          "value": "e"
+        }
+      ]
+    },
+    "type": "unsupported-import",
+    "message": "Unsupported 'require' call cannot be transformed into an import"
+  }
+]

--- a/test/form/modules.commonjs/skips-require-after-side-effect/main.js
+++ b/test/form/modules.commonjs/skips-require-after-side-effect/main.js
@@ -1,0 +1,4 @@
+let a = require('a');
+let b = require('b');
+window.d = d;
+let e = require('e');

--- a/test/form/modules.commonjs/skips-require-after-throw/_expected/main.js
+++ b/test/form/modules.commonjs/skips-require-after-throw/_expected/main.js
@@ -1,0 +1,4 @@
+import a from 'a';
+import b from 'b';
+throw c;
+let d = require('d');

--- a/test/form/modules.commonjs/skips-require-after-throw/_expected/metadata.json
+++ b/test/form/modules.commonjs/skips-require-after-throw/_expected/metadata.json
@@ -1,0 +1,88 @@
+{
+  "modules.commonjs": {
+    "imports": [
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "a",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "a"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "a",
+            "exportName": "default"
+          }
+        ],
+        "path": "a"
+      },
+      {
+        "type": "default-import",
+        "node": {
+          "type": "VariableDeclaration",
+          "kind": "let",
+          "declarations": [
+            {
+              "type": "VariableDeclarator",
+              "id": {
+                "type": "Identifier",
+                "name": "b",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "init": {
+                "type": "CallExpression",
+                "callee": {
+                  "type": "Identifier",
+                  "name": "require",
+                  "decorators": null,
+                  "typeAnnotation": null
+                },
+                "arguments": [
+                  {
+                    "type": "StringLiteral",
+                    "value": "b"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "bindings": [
+          {
+            "localName": "b",
+            "exportName": "default"
+          }
+        ],
+        "path": "b"
+      }
+    ],
+    "exports": [],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/skips-require-after-throw/_expected/warnings.json
+++ b/test/form/modules.commonjs/skips-require-after-throw/_expected/warnings.json
@@ -1,0 +1,60 @@
+[
+  {
+    "node": {
+      "type": "CallExpression",
+      "start": 61,
+      "end": 73,
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 8
+        },
+        "end": {
+          "line": 4,
+          "column": 20
+        }
+      },
+      "callee": {
+        "type": "Identifier",
+        "start": 61,
+        "end": 68,
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 8
+          },
+          "end": {
+            "line": 4,
+            "column": 15
+          },
+          "identifierName": "require"
+        },
+        "name": "require"
+      },
+      "arguments": [
+        {
+          "type": "StringLiteral",
+          "start": 69,
+          "end": 72,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 16
+            },
+            "end": {
+              "line": 4,
+              "column": 19
+            }
+          },
+          "extra": {
+            "rawValue": "d",
+            "raw": "'d'"
+          },
+          "value": "d"
+        }
+      ]
+    },
+    "type": "unsupported-import",
+    "message": "Unsupported 'require' call cannot be transformed into an import"
+  }
+]

--- a/test/form/modules.commonjs/skips-require-after-throw/main.js
+++ b/test/form/modules.commonjs/skips-require-after-throw/main.js
@@ -1,0 +1,4 @@
+let a = require('a');
+let b = require('b');
+throw c;
+let d = require('d');


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/982

As soon as we see any statement that could modify `window` (or another global)
in any way, we need to stop converting `require` to `import`, since otherwise we
might introduce bugs due to execution reordering.