### PR TITLE
feat: add an option to force a single default export

### DIFF
--- a/test/form/modules.commonjs/converts-complex-forced-default-export/_expected/main.js
+++ b/test/form/modules.commonjs/converts-complex-forced-default-export/_expected/main.js
@@ -1,0 +1,16 @@
+console.log('Start of file');
+let defaultExport = {};
+defaultExport = a;
+if (b) {
+  defaultExport.d = e;
+}
+for (let f in defaultExport) {
+  defaultExport[f]++;
+}
+defaultExport[g] = {
+  h() {
+    console.log(this);
+  }
+};
+export default defaultExport;
+console.log('End of file');

--- a/test/form/modules.commonjs/converts-complex-forced-default-export/_expected/metadata.json
+++ b/test/form/modules.commonjs/converts-complex-forced-default-export/_expected/metadata.json
@@ -1,0 +1,7 @@
+{
+  "modules.commonjs": {
+    "imports": [],
+    "exports": [],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/converts-complex-forced-default-export/config.json
+++ b/test/form/modules.commonjs/converts-complex-forced-default-export/config.json
@@ -1,0 +1,7 @@
+{
+  "options": {
+    "modules.commonjs": {
+      "forceDefaultExport": true
+    }
+  }
+}

--- a/test/form/modules.commonjs/converts-complex-forced-default-export/main.js
+++ b/test/form/modules.commonjs/converts-complex-forced-default-export/main.js
@@ -1,0 +1,14 @@
+console.log('Start of file');
+module.exports = a;
+if (b) {
+  this.d = e;
+}
+for (let f in exports) {
+  module.exports[f]++;
+}
+exports[g] = {
+  h() {
+    console.log(this);
+  }
+};
+console.log('End of file');

--- a/test/form/modules.commonjs/converts-simple-forced-default-export/_expected/main.js
+++ b/test/form/modules.commonjs/converts-simple-forced-default-export/_expected/main.js
@@ -1,0 +1,4 @@
+export default {
+  a,
+  b,
+};

--- a/test/form/modules.commonjs/converts-simple-forced-default-export/_expected/metadata.json
+++ b/test/form/modules.commonjs/converts-simple-forced-default-export/_expected/metadata.json
@@ -1,0 +1,75 @@
+{
+  "modules.commonjs": {
+    "imports": [],
+    "exports": [
+      {
+        "type": "default-export",
+        "node": {
+          "type": "ExpressionStatement",
+          "expression": {
+            "type": "AssignmentExpression",
+            "operator": "=",
+            "left": {
+              "type": "MemberExpression",
+              "object": {
+                "type": "Identifier",
+                "name": "module",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "property": {
+                "type": "Identifier",
+                "name": "exports",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "computed": false
+            },
+            "right": {
+              "type": "ObjectExpression",
+              "properties": [
+                {
+                  "type": "ObjectProperty",
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "name": "a",
+                    "decorators": null,
+                    "typeAnnotation": null
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "name": "a",
+                    "decorators": null,
+                    "typeAnnotation": null
+                  },
+                  "shorthand": true,
+                  "decorators": null
+                },
+                {
+                  "type": "ObjectProperty",
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "name": "b",
+                    "decorators": null,
+                    "typeAnnotation": null
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "name": "b",
+                    "decorators": null,
+                    "typeAnnotation": null
+                  },
+                  "shorthand": true,
+                  "decorators": null
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/converts-simple-forced-default-export/config.json
+++ b/test/form/modules.commonjs/converts-simple-forced-default-export/config.json
@@ -1,0 +1,7 @@
+{
+  "options": {
+    "modules.commonjs": {
+      "forceDefaultExport": true
+    }
+  }
+}

--- a/test/form/modules.commonjs/converts-simple-forced-default-export/main.js
+++ b/test/form/modules.commonjs/converts-simple-forced-default-export/main.js
@@ -1,0 +1,4 @@
+module.exports = {
+  a,
+  b,
+};


### PR DESCRIPTION
This is useful for code that does complex modifications to `module.exports` and
where we still want to use JS modules. Rather than changing things to exports
line-by-line, we declare an empty exports object at the top, then do the normal
modifications, then `export default` it at the bottom.