### PR TITLE
fix: use appendLeft to avoid magic-string conflicts in modules.commonjs

### DIFF
--- a/test/form/modules.commonjs/allows-multiple-named-exports-with-conflicts/_expected/main.js
+++ b/test/form/modules.commonjs/allows-multiple-named-exports-with-conflicts/_expected/main.js
@@ -1,0 +1,6 @@
+let a = 1;
+let b = 2;
+let a$1 = 3;
+export { a$1 as a };
+let b$1 = 4;
+export { b$1 as b };

--- a/test/form/modules.commonjs/allows-multiple-named-exports-with-conflicts/_expected/metadata.json
+++ b/test/form/modules.commonjs/allows-multiple-named-exports-with-conflicts/_expected/metadata.json
@@ -1,0 +1,80 @@
+{
+  "modules.commonjs": {
+    "imports": [],
+    "exports": [
+      {
+        "type": "named-export",
+        "bindings": [
+          {
+            "exportName": "a",
+            "localName": "a$1"
+          }
+        ],
+        "node": {
+          "type": "ExpressionStatement",
+          "expression": {
+            "type": "AssignmentExpression",
+            "operator": "=",
+            "left": {
+              "type": "MemberExpression",
+              "object": {
+                "type": "Identifier",
+                "name": "exports",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "property": {
+                "type": "Identifier",
+                "name": "a",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "computed": false
+            },
+            "right": {
+              "type": "NumericLiteral",
+              "value": 3
+            }
+          }
+        }
+      },
+      {
+        "type": "named-export",
+        "bindings": [
+          {
+            "exportName": "b",
+            "localName": "b$1"
+          }
+        ],
+        "node": {
+          "type": "ExpressionStatement",
+          "expression": {
+            "type": "AssignmentExpression",
+            "operator": "=",
+            "left": {
+              "type": "MemberExpression",
+              "object": {
+                "type": "Identifier",
+                "name": "exports",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "property": {
+                "type": "Identifier",
+                "name": "b",
+                "decorators": null,
+                "typeAnnotation": null
+              },
+              "computed": false
+            },
+            "right": {
+              "type": "NumericLiteral",
+              "value": 4
+            }
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/form/modules.commonjs/allows-multiple-named-exports-with-conflicts/config.json
+++ b/test/form/modules.commonjs/allows-multiple-named-exports-with-conflicts/config.json
@@ -1,0 +1,3 @@
+{
+  "description": "allows multiple named exports with conflicts"
+}

--- a/test/form/modules.commonjs/allows-multiple-named-exports-with-conflicts/main.js
+++ b/test/form/modules.commonjs/allows-multiple-named-exports-with-conflicts/main.js
@@ -1,0 +1,4 @@
+let a = 1;
+let b = 2;
+exports.a = 3;
+exports.b = 4;


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/1012

As in decaffeinate, it's easy to accidentally overwrite code when using
magic-string, so we use appendLeft everywhere and always patch code in order,
which fixes a particular bug involving named exports.