### PR TITLE
fix: add basic TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,41 @@
+import { Node, NodePath } from 'babel-traverse';
+
+declare module "esnext" {
+  type Plugin = {
+    name: string,
+    description: string,
+  };
+
+  type DeclarationsBlockScopeOptions = {
+    disableConst?: boolean | ((path: NodePath<Node>) => boolean),
+  };
+
+  type ModulesCommonJSOptions = {
+    forceDefaultExport?: boolean,
+    safeFunctionIdentifiers?: Array<string>,
+  };
+
+  type Options = {
+    plugins?: Array<Plugin>,
+    validate?: boolean,
+    'declarations.block-scope'?: DeclarationsBlockScopeOptions,
+    'modules.commonjs'?: ModulesCommonJSOptions,
+  };
+
+  type Warning = {
+    node: Node,
+    type: string,
+    message: string
+  };
+
+  type RenderedModule = {
+    ast: Node,
+    code: string,
+    metadata: Object,
+    warnings: Array<Warning>,
+  };
+
+  export function run(args: Array<string>): void;
+  export const allPlugins: Array<Plugin>;
+  export function convert(source: string, options?: Options): RenderedModule;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Update your project to the latest ECMAScript syntax.",
   "main": "dist/esnext.js",
   "jsnext:main": "dist/esnext.mjs",
+  "types": "index.d.ts",
   "bin": {
     "esnext": "./bin/index.js"
   },
@@ -36,6 +37,7 @@
   },
   "bugs": "https://github.com/esnext/esnext/issues",
   "dependencies": {
+    "@types/babel-traverse": "^6.7.17",
     "babel-traverse": "^6.21.0",
     "babel-types": "^6.21.0",
     "babylon": "^6.14.1",


### PR DESCRIPTION
I left off the `Plugin.visitor` method since it had a complex type that isn't
necessary for any decaffeinate usages, but it would be needed for any
externally-specified plugins.