### PR TITLE
fix: clean up typescript definitions, update magic-string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,41 +1,39 @@
 import { Node, NodePath } from 'babel-traverse';
 
-declare module "esnext" {
-  type Plugin = {
-    name: string,
-    description: string,
-  };
+type Plugin = {
+  name: string,
+  description: string,
+};
 
-  type DeclarationsBlockScopeOptions = {
-    disableConst?: boolean | ((path: NodePath<Node>) => boolean),
-  };
+type DeclarationsBlockScopeOptions = {
+  disableConst?: boolean | ((path: NodePath<Node>) => boolean),
+};
 
-  type ModulesCommonJSOptions = {
-    forceDefaultExport?: boolean,
-    safeFunctionIdentifiers?: Array<string>,
-  };
+type ModulesCommonJSOptions = {
+  forceDefaultExport?: boolean,
+  safeFunctionIdentifiers?: Array<string>,
+};
 
-  type Options = {
-    plugins?: Array<Plugin>,
-    validate?: boolean,
-    'declarations.block-scope'?: DeclarationsBlockScopeOptions,
-    'modules.commonjs'?: ModulesCommonJSOptions,
-  };
+type Options = {
+  plugins?: Array<Plugin>,
+  validate?: boolean,
+  'declarations.block-scope'?: DeclarationsBlockScopeOptions,
+  'modules.commonjs'?: ModulesCommonJSOptions,
+};
 
-  type Warning = {
-    node: Node,
-    type: string,
-    message: string
-  };
+type Warning = {
+  node: Node,
+  type: string,
+  message: string
+};
 
-  type RenderedModule = {
-    ast: Node,
-    code: string,
-    metadata: Object,
-    warnings: Array<Warning>,
-  };
+type RenderedModule = {
+  ast: Node,
+  code: string,
+  metadata: Object,
+  warnings: Array<Warning>,
+};
 
-  export function run(args: Array<string>): void;
-  export const allPlugins: Array<Plugin>;
-  export function convert(source: string, options?: Options): RenderedModule;
-}
+export function run(args: Array<string>): void;
+export const allPlugins: Array<Plugin>;
+export function convert(source: string, options?: Options): RenderedModule;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-traverse": "^6.21.0",
     "babel-types": "^6.21.0",
     "babylon": "^6.14.1",
-    "magic-string": "^0.19.0",
+    "magic-string": "^0.22.1",
     "mkdirp": "^0.5.1",
     "shebang-regex": "^2.0.0",
     "strip-indent": "^2.0.0"


### PR DESCRIPTION
We shouldn't use `declare module` for library definitions like this (even though
it usually works).