### PR TITLE
fix: don't convert `var` to `let` or `const` in a switch case

### DIFF
--- a/src/utils/mostRestrictiveKindForDeclaration.js
+++ b/src/utils/mostRestrictiveKindForDeclaration.js
@@ -13,6 +13,10 @@ export default function mostRestrictiveKindForDeclaration(path: Path): Declarati
   let { scope } = path;
   let isConst = path.node.declarations.every(declaration => declaration.init);
 
+  if (t.isSwitchCase(path.parent)) {
+    return 'var';
+  }
+
   for (let id in ids) {
     let binding = scope.getBinding(id);
 

--- a/test/form/declarations.block-scope/var-in-switch/_expected/main.js
+++ b/test/form/declarations.block-scope/var-in-switch/_expected/main.js
@@ -1,0 +1,10 @@
+switch (a) {
+  case 1:
+    var x = 1;
+    console.log(x);
+    break;
+  case 2:
+    x = 2;
+    console.log(x);
+    break;
+}

--- a/test/form/declarations.block-scope/var-in-switch/_expected/metadata.json
+++ b/test/form/declarations.block-scope/var-in-switch/_expected/metadata.json
@@ -1,0 +1,5 @@
+{
+  "declarations.block-scope": {
+    "declarations": []
+  }
+}

--- a/test/form/declarations.block-scope/var-in-switch/_expected/warnings.json
+++ b/test/form/declarations.block-scope/var-in-switch/_expected/warnings.json
@@ -1,0 +1,76 @@
+[
+  {
+    "node": {
+      "type": "VariableDeclaration",
+      "start": 27,
+      "end": 37,
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 4
+        },
+        "end": {
+          "line": 3,
+          "column": 14
+        }
+      },
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 31,
+          "end": 36,
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 13
+            }
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 31,
+            "end": 32,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 8
+              },
+              "end": {
+                "line": 3,
+                "column": 9
+              },
+              "identifierName": "x"
+            },
+            "name": "x"
+          },
+          "init": {
+            "type": "NumericLiteral",
+            "start": 35,
+            "end": 36,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 12
+              },
+              "end": {
+                "line": 3,
+                "column": 13
+              }
+            },
+            "extra": {
+              "rawValue": 1,
+              "raw": "1"
+            },
+            "value": 1
+          }
+        }
+      ],
+      "kind": "var"
+    },
+    "type": "unsupported-declaration",
+    "message": "'var' declaration cannot be converted to block scope"
+  }
+]

--- a/test/form/declarations.block-scope/var-in-switch/config.json
+++ b/test/form/declarations.block-scope/var-in-switch/config.json
@@ -1,0 +1,3 @@
+{
+  "description": "does not convert `var` declarations within switch cases"
+}

--- a/test/form/declarations.block-scope/var-in-switch/main.js
+++ b/test/form/declarations.block-scope/var-in-switch/main.js
@@ -1,0 +1,10 @@
+switch (a) {
+  case 1:
+    var x = 1;
+    console.log(x);
+    break;
+  case 2:
+    x = 2;
+    console.log(x);
+    break;
+}


### PR DESCRIPTION
Fixes https://github.com/decaffeinate/decaffeinate/issues/1171

Potentially add-variable-declarations and esnext could be smarter in this case,
e.g. by declaring the variable outside the switch or even creating a block
scope, but the easy thing is to just keep the declaration as `var`. Since `var`
doesn't have a temporal dead zone, a declaration in any switch case will work
for all switch cases.