### PR TITLE
test(fixtures): update with new AST format

### DIFF
--- a/test/form/declarations.block-scope/var-with-own-binding-in-initializer/_expected/ast.json
+++ b/test/form/declarations.block-scope/var-with-own-binding-in-initializer/_expected/ast.json
@@ -104,7 +104,6 @@
                 },
                 "id": null,
                 "generator": false,
-                "expression": false,
                 "async": false,
                 "params": [],
                 "body": {

--- a/test/form/declarations.block-scope/var-with-own-binding-in-initializer/_expected/warnings.json
+++ b/test/form/declarations.block-scope/var-with-own-binding-in-initializer/_expected/warnings.json
@@ -76,7 +76,6 @@
               },
               "id": null,
               "generator": false,
-              "expression": false,
               "async": false,
               "params": [],
               "body": {


### PR DESCRIPTION
It seems `expression` was removed from `ArrowFunctionExpression`.