### PR TITLE
chore: fix publish by switching to `npm publish`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prebuild": "yarn lint && rm -rf dist",
     "build": "rollup -c",
     "prepublish": "yarn build",
-    "semantic-release": "semantic-release pre && yarn publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "keywords": [
     "es6",


### PR DESCRIPTION
We can't use `yarn publish` from travis since it's interactive.

Probably this could be cleaner with a newer semantic-release, but this should at
least get publish working again.