### PR TITLE
fix: use babel-traverse, not @babel/traverse in typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Node, NodePath } from '@babel/traverse';
+import { Node, NodePath } from 'babel-traverse';
 
 export { Node, NodePath };
 


### PR DESCRIPTION
The DefinitelyTyped typings are for babel-traverse, and that's what we expose as
a package dependency, so we need to just use those for now.